### PR TITLE
feat: prepare crates for publication to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,17 @@
 [package]
 name = "coapum"
 version = "0.2.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition = "2024"
+rust-version = "1.85.0"
+authors = ["Jared Wolff <jared@jaredwolff.com>"]
+description = "A modern, ergonomic CoAP (Constrained Application Protocol) library for Rust with support for DTLS, observers, and asynchronous handlers"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/jaredwolff/coapum"
+documentation = "https://docs.rs/coapum"
+homepage = "https://github.com/jaredwolff/coapum"
+keywords = ["coap", "iot", "dtls", "async", "sensor"]
+categories = ["network-programming", "embedded", "api-bindings", "asynchronous"]
+readme = "README.md"
 [features]
 default = ["sled-observer"]
 sled-observer = ["sled"]
@@ -33,7 +41,7 @@ webrtc-dtls = { version = "0.12" }
 webrtc-util = { version = "0.11" }
 
 # SenML
-coapum-senml = { path = "./coapum-senml" }
+coapum-senml = { version = "0.1.0", path = "./coapum-senml" }
 
 
 [dev-dependencies]

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,203 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (which shall not include Header Communications).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based upon (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and derivative works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control
+      systems, and issue tracking systems that are managed by, or on behalf
+      of, the Licensor for the purpose of discussing and improving the Work,
+      but excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to use, reproduce, modify, distribute, prepare
+      Derivative Works of, publicly display, publicly perform, sublicense,
+      and sell the Work and to permit persons to whom the Work is
+      furnished to do so, subject to the following conditions:
+
+      The above copyright notice and this permission notice shall be included
+      in all copies or substantial portions of the Work.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, trademark, patent,
+          attribution and other notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+      that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright notice to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. You may elect to provide, for a
+      fee or free of charge, warranty, support, indemnity or other
+      liability obligations and/or rights consistent with this License.
+      However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same page as the copyright notice for easier identification within
+      third-party archives.
+
+   Copyright 2025 Jared Wolff
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jared Wolff
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/benches/router_bench.rs
+++ b/benches/router_bench.rs
@@ -1,11 +1,12 @@
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
 use coapum::{
+    Raw,
     router::{CoapumRequest, RouterBuilder},
-    Raw, {CoapRequest, Packet},
+    {CoapRequest, Packet},
 };
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use serde_json::json;
 use tower::Service; // make sure to use your actual project name and import path
 

--- a/examples/cbor_client.rs
+++ b/examples/cbor_client.rs
@@ -3,7 +3,7 @@ use std::{net::SocketAddr, sync::Arc};
 use tokio::net::UdpSocket;
 
 use coapum::{
-    dtls::{cipher_suite::CipherSuiteId, config::Config, conn::DTLSConn, Error},
+    dtls::{Error, cipher_suite::CipherSuiteId, config::Config, conn::DTLSConn},
     util::Conn,
     {CoapRequest, ContentFormat, Packet, RequestType},
 };

--- a/examples/cbor_server.rs
+++ b/examples/cbor_server.rs
@@ -51,9 +51,9 @@ use std::{
 
 use coapum::{
     dtls::{
+        Error,
         cipher_suite::CipherSuiteId,
         config::{Config, ExtendedMasterSecretType},
-        Error,
     },
     extract::{Cbor, Identity, Path, State, StatusCode},
     observer::sled::SledObserver,

--- a/examples/concurrency.rs
+++ b/examples/concurrency.rs
@@ -3,14 +3,14 @@ use std::{net::SocketAddr, sync::Arc};
 use tokio::net::UdpSocket;
 
 use coapum::{
+    CoapRequest, ContentFormat, Packet, RequestType,
     dtls::{
+        Error,
         cipher_suite::CipherSuiteId,
         config::{Config, ExtendedMasterSecretType},
         conn::DTLSConn,
-        Error,
     },
     util::Conn,
-    CoapRequest, ContentFormat, Packet, RequestType,
 };
 
 // const IDENTITY: &[u8] = "goobie!".as_bytes();

--- a/examples/dynamic_client_management.rs
+++ b/examples/dynamic_client_management.rs
@@ -6,11 +6,11 @@
 //! Run with: cargo run --example dynamic_client_management
 
 use coapum::{
-    config::Config, observer::memory::MemObserver, serve::serve_with_client_management,
-    ClientManager, RouterBuilder,
+    ClientManager, RouterBuilder, config::Config, observer::memory::MemObserver,
+    serve::serve_with_client_management,
 };
 use std::collections::HashMap;
-use tokio::time::{interval, Duration};
+use tokio::time::{Duration, interval};
 
 #[derive(Clone, Debug)]
 struct AppState {

--- a/examples/external_state_updates.rs
+++ b/examples/external_state_updates.rs
@@ -7,11 +7,11 @@
 //! Run with: cargo run --example external_state_updates
 
 use coapum::{
-    config::Config, observer::memory::MemObserver, router::RouterBuilder, serve::serve,
-    StateUpdateHandle,
+    StateUpdateHandle, config::Config, observer::memory::MemObserver, router::RouterBuilder,
+    serve::serve,
 };
 use std::collections::HashMap;
-use tokio::time::{interval, Duration};
+use tokio::time::{Duration, interval};
 
 #[derive(Clone, Debug)]
 struct AppState {

--- a/examples/raw_client.rs
+++ b/examples/raw_client.rs
@@ -3,14 +3,14 @@ use std::{net::SocketAddr, sync::Arc};
 use tokio::net::UdpSocket;
 
 use coapum::{
+    CoapRequest, ContentFormat, Packet, RequestType,
     dtls::{
+        Error,
         cipher_suite::CipherSuiteId,
         config::{Config, ExtendedMasterSecretType},
         conn::DTLSConn,
-        Error,
     },
     util::Conn,
-    CoapRequest, ContentFormat, Packet, RequestType,
 };
 
 const IDENTITY: &[u8] = "goobie!".as_bytes();

--- a/examples/raw_server.rs
+++ b/examples/raw_server.rs
@@ -5,14 +5,15 @@ use std::{
 };
 
 use coapum::{
+    Raw,
     dtls::{
+        Error,
         cipher_suite::CipherSuiteId,
         config::{Config, ExtendedMasterSecretType},
-        Error,
     },
     observer::sled::SledObserver,
     router::RouterBuilder,
-    serve, Raw,
+    serve,
 };
 
 type PskStore = Arc<RwLock<HashMap<String, Vec<u8>>>>;

--- a/examples/senml_simple.rs
+++ b/examples/senml_simple.rs
@@ -6,7 +6,7 @@
 //! 3. Demonstrate both JSON and CBOR format support
 
 use coapum::{
-    extract::SenML, observer::memory::MemObserver, router::RouterBuilder, serve, StatusCode,
+    StatusCode, extract::SenML, observer::memory::MemObserver, router::RouterBuilder, serve,
 };
 use coapum_senml::SenMLBuilder;
 

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -4,9 +4,9 @@
 //! into CoAP handlers that can be used with the router. It supports automatic
 //! extraction of parameters from requests and conversion of return values to responses.
 
+use crate::CoapResponse;
 use crate::extract::{FromRequest, IntoResponse};
 use crate::router::CoapumRequest;
-use crate::CoapResponse;
 use async_trait::async_trait;
 use std::{convert::Infallible, future::Future, marker::PhantomData, net::SocketAddr, sync::Arc};
 use tokio::sync::Mutex;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub use extract::{
     Bytes, Cbor, FromRequest, Identity, IntoResponse, Json, ObserveFlag, Path, Raw, Source, State,
     StatusCode,
 };
-pub use handler::{into_handler, Handler, HandlerFn};
+pub use handler::{Handler, HandlerFn, into_handler};
 pub use router::{
     ClientManager, ClientManagerError, ClientMetadata, NotificationTrigger, RouterBuilder,
     StateUpdateError, StateUpdateHandle,

--- a/src/observer/memory.rs
+++ b/src/observer/memory.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use serde_json::Value;
-use tokio::sync::{mpsc::Sender, RwLock};
+use tokio::sync::{RwLock, mpsc::Sender};
 
 use super::{Observer, ObserverValue};
 
@@ -359,13 +359,15 @@ mod tests {
             .unregister("123", "/observe_and_write")
             .await
             .unwrap();
-        assert!(!observer
-            .channels
-            .read()
-            .await
-            .get("123")
-            .map(|device_channels| device_channels.contains_key("/observe_and_write"))
-            .unwrap_or(false));
+        assert!(
+            !observer
+                .channels
+                .read()
+                .await
+                .get("123")
+                .map(|device_channels| device_channels.contains_key("/observe_and_write"))
+                .unwrap_or(false)
+        );
 
         observer
             .register("123", "/observe_and_write", Arc::new(tx.clone()))

--- a/src/observer/mod.rs
+++ b/src/observer/mod.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
 use async_trait::async_trait;
-use serde_json::{map::Entry, Value};
+use serde_json::{Value, map::Entry};
 use tokio::sync::mpsc::Sender;
 
 pub mod memory;

--- a/src/observer/sled.rs
+++ b/src/observer/sled.rs
@@ -3,8 +3,8 @@ use std::{collections::HashMap, fmt, sync::Arc};
 use async_trait::async_trait;
 use serde_json::Value;
 use tokio::sync::{
-    mpsc::{channel, Sender},
     RwLock,
+    mpsc::{Sender, channel},
 };
 
 use super::{Observer, ObserverValue};
@@ -485,13 +485,15 @@ mod tests {
             .unregister("123", "/observe_and_write")
             .await
             .unwrap();
-        assert!(!observer
-            .channels
-            .read()
-            .await
-            .get("123")
-            .map(|device_channels| device_channels.contains_key("/observe_and_write"))
-            .unwrap_or(false));
+        assert!(
+            !observer
+                .channels
+                .read()
+                .await
+                .get("123")
+                .map(|device_channels| device_channels.contains_key("/observe_and_write"))
+                .unwrap_or(false)
+        );
         assert!(observer.channel.is_none());
 
         observer

--- a/src/observer/subscriber.rs
+++ b/src/observer/subscriber.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use serde_json::Value;
-use tokio::sync::{broadcast, Mutex};
+use tokio::sync::{Mutex, broadcast};
 
 use super::{merge_json, path_to_json};
 

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -17,7 +17,7 @@ use tokio::sync::mpsc::{self, Sender};
 use tokio::sync::{Mutex, RwLock};
 use tower::Service;
 
-use crate::handler::{into_erased_handler, into_handler, ErasedHandler, Handler, HandlerFn};
+use crate::handler::{ErasedHandler, Handler, HandlerFn, into_erased_handler, into_handler};
 use crate::observer::{Observer, ObserverRequest, ObserverValue};
 use crate::router::wrapper::IntoCoapResponse;
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -7,11 +7,11 @@ use std::{
 };
 
 use tokio::sync::{
-    mpsc::{self, channel, Sender},
     Mutex, RwLock,
+    mpsc::{self, Sender, channel},
 };
 use tower::Service;
-use webrtc_dtls::{conn::DTLSConn, listener, Error};
+use webrtc_dtls::{Error, conn::DTLSConn, listener};
 use webrtc_util::conn::Listener;
 
 use coap_lite::{CoapRequest, ObserveOption, Packet, RequestType, ResponseType};
@@ -191,7 +191,9 @@ where
                         if old_conn.established_at.elapsed() < MIN_RECONNECT_INTERVAL {
                             log::warn!(
                                 "Rate limited: Rapid reconnection attempt from {} for identity '{}' (interval: {:?})",
-                                socket_addr, identity, old_conn.established_at.elapsed()
+                                socket_addr,
+                                identity,
+                                old_conn.established_at.elapsed()
                             );
                             return; // Skip this connection attempt
                         }
@@ -200,7 +202,9 @@ where
                         if old_conn.reconnect_count > MAX_RECONNECT_ATTEMPTS {
                             log::error!(
                                 "Security: Too many reconnection attempts from {} for identity '{}' (count: {})",
-                                socket_addr, identity, old_conn.reconnect_count
+                                socket_addr,
+                                identity,
+                                old_conn.reconnect_count
                             );
                             return; // Block this identity
                         }

--- a/tests/client_manager_tests.rs
+++ b/tests/client_manager_tests.rs
@@ -1,12 +1,12 @@
 //! Tests for real-time client/key management functionality
 
 use coapum::{
-    router::{ClientCommand, ClientEntry, ClientManager, ClientMetadata, ClientStore},
     ClientManagerError,
+    router::{ClientCommand, ClientEntry, ClientManager, ClientMetadata, ClientStore},
 };
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::{RwLock, mpsc};
 
 #[tokio::test]
 async fn test_client_manager_add_remove() {

--- a/tests/error_path_coverage.rs
+++ b/tests/error_path_coverage.rs
@@ -6,10 +6,10 @@
 use std::sync::Arc;
 
 use coapum::{
+    ContentFormat,
     extract::{Cbor, Json, StatusCode},
     observer::memory::MemObserver,
     router::RouterBuilder,
-    ContentFormat,
 };
 use serde::{Deserialize, Serialize};
 use tower::Service;

--- a/tests/handler_advanced_tests.rs
+++ b/tests/handler_advanced_tests.rs
@@ -6,10 +6,10 @@
 use std::sync::Arc;
 
 use coapum::{
+    ContentFormat,
     extract::{Bytes, Cbor, Json, Path, Source, State, StatusCode},
     observer::memory::MemObserver,
     router::RouterBuilder,
-    ContentFormat,
 };
 use serde::{Deserialize, Serialize};
 use tower::Service;

--- a/tests/handler_trait_coverage.rs
+++ b/tests/handler_trait_coverage.rs
@@ -7,10 +7,10 @@
 use std::sync::Arc;
 
 use coapum::{
+    ContentFormat,
     extract::{Bytes, Cbor, Json, Path, Source, State, StatusCode},
     observer::memory::MemObserver,
     router::RouterBuilder,
-    ContentFormat,
 };
 use serde::{Deserialize, Serialize};
 use tower::Service;

--- a/tests/observe_integration.rs
+++ b/tests/observe_integration.rs
@@ -12,24 +12,24 @@ use std::{
 
 use tokio::{
     net::UdpSocket,
-    sync::{broadcast, Mutex},
+    sync::{Mutex, broadcast},
     time::timeout,
 };
 
 use coapum::{
+    CoapRequest, ContentFormat, Packet, RequestType, ResponseType,
     config::Config as ServerConfig,
     dtls::{
+        Error as DtlsError,
         cipher_suite::CipherSuiteId,
         config::{Config as DtlsConfig, ExtendedMasterSecretType},
         conn::DTLSConn,
-        Error as DtlsError,
     },
     extract::{Cbor, Path, State, StatusCode},
     observer::{memory::MemObserver, sled::SledObserver},
     router::RouterBuilder,
     serve,
     util::Conn,
-    CoapRequest, ContentFormat, Packet, RequestType, ResponseType,
 };
 
 use coap_lite::ObserveOption;

--- a/tests/observe_push_notifications.rs
+++ b/tests/observe_push_notifications.rs
@@ -18,19 +18,19 @@ use tokio::{
 };
 
 use coapum::{
+    CoapRequest, Packet, RequestType, ResponseType,
     config::Config as ServerConfig,
     dtls::{
+        Error as DtlsError,
         cipher_suite::CipherSuiteId,
         config::{Config as DtlsConfig, ExtendedMasterSecretType},
         conn::DTLSConn,
-        Error as DtlsError,
     },
     extract::{Cbor, Path, State, StatusCode},
-    observer::{memory::MemObserver, Observer},
+    observer::{Observer, memory::MemObserver},
     router::RouterBuilder,
     serve,
     util::Conn,
-    CoapRequest, Packet, RequestType, ResponseType,
 };
 
 use coap_lite::ObserveOption;

--- a/tests/security_tests.rs
+++ b/tests/security_tests.rs
@@ -4,10 +4,10 @@
 //! path validation, connection management, and injection attack prevention.
 
 use coapum::{
+    CoapRequest, ContentFormat, Packet,
     extract::{Cbor, FromRequest, Json},
     observer::memory::MemObserver,
     router::RouterBuilder,
-    CoapRequest, ContentFormat, Packet,
 };
 use serde::{Deserialize, Serialize};
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
@@ -118,10 +118,12 @@ mod payload_security_tests {
 
         let cbor_result = Cbor::<TestPayload>::from_request(&req, &()).await;
         assert!(cbor_result.is_err(), "CBOR should reject empty payload");
-        assert!(cbor_result
-            .unwrap_err()
-            .to_string()
-            .contains("Empty payload"));
+        assert!(
+            cbor_result
+                .unwrap_err()
+                .to_string()
+                .contains("Empty payload")
+        );
 
         // Test JSON empty payload
         let mut req = create_test_request_with_payload(empty_payload);
@@ -130,10 +132,12 @@ mod payload_security_tests {
 
         let json_result = Json::<TestPayload>::from_request(&req, &()).await;
         assert!(json_result.is_err(), "JSON should reject empty payload");
-        assert!(json_result
-            .unwrap_err()
-            .to_string()
-            .contains("Empty payload"));
+        assert!(
+            json_result
+                .unwrap_err()
+                .to_string()
+                .contains("Empty payload")
+        );
     }
 
     #[tokio::test]
@@ -150,10 +154,12 @@ mod payload_security_tests {
 
         let result = Cbor::<TestPayload>::from_request(&req, &()).await;
         assert!(result.is_err(), "Should reject wrong content type");
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Expected CBOR content type"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Expected CBOR content type")
+        );
     }
 }
 

--- a/tests/state_update_core_tests.rs
+++ b/tests/state_update_core_tests.rs
@@ -1,6 +1,6 @@
 //! Core tests for external state update functionality
 
-use coapum::{observer::memory::MemObserver, router::CoapRouter, StateUpdateError};
+use coapum::{StateUpdateError, observer::memory::MemObserver, router::CoapRouter};
 use std::collections::HashMap;
 
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
## Summary

Prepares both `coapum` and `coapum-senml` crates for publication to crates.io.

### Changes
- **Cargo.toml metadata**: Added authors, description, license, repository, keywords, categories
- **LICENSE files**: Created MIT and Apache 2.0 license files
- **README updates**: Fixed API examples, added SenML documentation, updated extractor list
- **Publication ready**: Dry-run publishing succeeds for both crates

### Post-merge steps
1. `cargo login <token>`
2. `(cd coapum-senml && cargo publish)` 
3. Remove `path = "./coapum-senml"` from main Cargo.toml
4. `cargo publish`

All tests pass, documentation builds successfully.